### PR TITLE
[add] build timestamp getter class

### DIFF
--- a/resources/BuildTimestamp.js
+++ b/resources/BuildTimestamp.js
@@ -1,0 +1,43 @@
+/**
+ * @class BuildTimestamp
+ */
+"use strict";
+
+let Build_Timestamp;
+try {
+   Build_Timestamp = BUILD_TIMESTAMP;
+   /* global VERSION */
+   /* Version from package.json. Set by the DefinePlugin in webpack. */
+} catch (err) {
+   console.warn("Build_Timestamp variable not found");
+}
+
+class Build_TimestampFinder {
+   constructor() {
+      this.Build_Timestamp = Build_Timestamp;
+      console.assert(Build_Timestamp, "Build_Timestamp not found")
+      // Uncomment to disable updater
+      //return;
+   }
+
+   /**
+    * @return {Promise}
+    */
+   getBuild_Timestamp() {
+      // 2024-02-29T12:00:43+07:00
+      // convert to 2024/02/29 12:00
+      let options = {
+         year: "numeric",
+         month: "2-digit",
+         day: "2-digit",
+         hour: "2-digit",
+         minute: "2-digit",
+      };
+      let displayDate = new Date(Build_Timestamp).toLocaleDateString("en-US", options);
+      return displayDate
+   }
+
+}
+
+var BuildTimestamp = new Build_TimestampFinder();
+export default BuildTimestamp;

--- a/resources/Updater.js
+++ b/resources/Updater.js
@@ -23,9 +23,13 @@ var config = require("../../config/config.js");
 
 const deploymentKeys = config.codepush.keys;
 
-var platform = "ios";
-if (String(navigator.userAgent).match("Android")) {
+var platform = "??";
+if (/Android/i.test(navigator.userAgent)) {
    platform = "android";
+} else if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+   platform = "ios";
+} else {
+   platform = "unknown";
 }
 
 class Updater extends EventEmitter {


### PR DESCRIPTION
We can't access it from the FW7 side for some reason, this also isolates it so it'll be easier to remove later
