### PR TITLE
[fix] if we are prioritizing local load, don't await DC reload

### DIFF
--- a/AppBuilder/platform/ABModel.js
+++ b/AppBuilder/platform/ABModel.js
@@ -98,8 +98,8 @@ module.exports = class ABModel extends ABModelCore {
       this.remote().create(copiedValues);
 
       await this.local().create(copiedValues);
+      this._reloadAffectedDC();
       this.object.emit("CREATE", copiedValues);
-      await this._reloadAffectedDC();
    }
 
    /**


### PR DESCRIPTION
Even though I am local-loading add-report, am still feeling like it's slow.
My debugging could be wrong, but it seems like the problem is that 5+ DCs have to be de-encrypted and loaded into memory.
Skipping this could cause other problems, but the "LocalLoad" function needs to be fast. If other things break they shouldn't use this option.

I cleared console while waiting, and had a breakpoint on when the redirect finally happened: 
The slow event seems to be refreshing `Moderators` ---- which is not critical for further editing of the report item

![image](https://github.com/digi-serve/appbuilder_platform_mobile/assets/8057443/defec34e-c8f6-4728-8822-e48ff29bf0cb)

